### PR TITLE
Update CMakeLists.txt to enable testing and add TAP tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   # Enable C++11 mode on GCC / Clang
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")
 endif()
-add_executable(path_demo path_demo.cpp filesystem/path.h filesystem/resolver.h)
+add_executable(path_demo 
+	path_demo.cpp 
+	filesystem/fwd.h 
+	filesystem/path.h 
+	filesystem/resolver.h
+)
+enable_testing()
+add_test(tests path_demo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 project(path)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -72,8 +72,9 @@ int main(int argc, char **argv) {
     IS(path("a/b/c/d").slice(0, 2), path("a/b"));
     IS(path("a/b/c/d").slice(0, 3), path("a/b/c"));
 
-    cout << path1 << endl;
-    cout << (path1/path1.as_relative()) << endl;
+	IS(path1, VOL SEP "dir 1" SEP "dir 2");
+
+	cout << (path1/path1.as_relative()) << endl;
     cout << (path1/path2) << endl;
     cout << (path1/path2).dirname() << endl;
     cout << (path1/path2).dirname().dirname() << endl;

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -39,21 +39,28 @@ int test_nr = 0;
     }
 
 // Platform specifics
-#if !defined(_WIN32)
-#define VOL     ""
-#define SEP     "/"
-#else
+#ifdef _WIN32
 #define VOL     "c:"
 #define SEP     "\\"
+#else
+#define VOL     ""
+#define SEP     "/"
 #endif
 
 int main(int argc, char **argv) {
     path path1(VOL SEP "dir 1" SEP "dir 2" SEP);
     path path2("dir 3");
 
-    IS(path1.length(), 2);
-    IS(path1[0], "dir 1");
-    IS(path1[1], "dir 2");
+#ifdef _WIN32
+    IS(path1.length(), 3);
+	IS(path1[0], "c:");
+	IS(path1[1], "dir 1");
+    IS(path1[2], "dir 2");
+#else
+	IS(path1.length(), 2);
+	IS(path1[0], "dir 1");
+	IS(path1[1], "dir 2");
+#endif
 
     NOK(path1.exists());
 


### PR DESCRIPTION
Enable testing in CMakeLists.txt
Add TAP tests to path_demo.cpp, converting output instructions to TAP assertions. This allows 
path_demo.cpp to be used as a test program.