### PR TITLE
use python with popen over realpath on OSX

### DIFF
--- a/filesystem.hpp
+++ b/filesystem.hpp
@@ -146,23 +146,23 @@ public:
 		char temp[PATH_MAX];
 
 		#if defined(__APPLE__)
-            // OSX *STILL* does not provide `realpath`, just use python
-            FILE *py_ret;
-            std::string py_code = "python -c 'import os; import sys;"
-                                  "sys.stdout.write("
-                                      "os.path.abspath(\"" + str() +
-                                  "\"))'";
-            py_ret = popen(py_code.c_str(), "r");
-            if (!py_ret) {
-                throw std::runtime_error("Could not obtain OSX absolute path using python: " + std::string(strerror(errno)));
-            }
-            // read in the buffer
-            while (fgets(temp, sizeof(temp), py_ret) != NULL) { }
-            pclose(py_ret);
-        #else
-            if (realpath(str().c_str(), temp) == NULL) {
-                throw std::runtime_error("Internal error in realpath(): " + std::string(strerror(errno)));
-            }
+			// OSX *STILL* does not provide `realpath`, just use python
+			FILE *py_ret;
+			std::string py_code = "python -c 'import os; import sys;"
+									"sys.stdout.write("
+									"os.path.abspath(\"" + str() +
+									"\"))'";
+			py_ret = popen(py_code.c_str(), "r");
+			if (!py_ret) {
+				throw std::runtime_error("Could not obtain OSX absolute path using python: " + std::string(strerror(errno)));
+			}
+			// read in the buffer
+			while (fgets(temp, sizeof(temp), py_ret) != NULL) { }
+			pclose(py_ret);
+		#else
+			if (realpath(str().c_str(), temp) == NULL) {
+				throw std::runtime_error("Internal error in realpath(): " + std::string(strerror(errno)));
+			}
 		#endif // __APPLE__
 
 		return path(temp);

--- a/filesystem.hpp
+++ b/filesystem.hpp
@@ -145,9 +145,25 @@ public:
 #if !defined(_WIN32)
 		char temp[PATH_MAX];
 
-		if (realpath(str().c_str(), temp) == NULL) {
-			throw std::runtime_error("Internal error in realpath(): " + std::string(strerror(errno)));
-		}
+		#if defined(__APPLE__)
+            // OSX *STILL* does not provide `realpath`, just use python
+            FILE *py_ret;
+            std::string py_code = "python -c 'import os; import sys;"
+                                  "sys.stdout.write("
+                                      "os.path.abspath(\"" + str() +
+                                  "\"))'";
+            py_ret = popen(py_code.c_str(), "r");
+            if (!py_ret) {
+                throw std::runtime_error("Could not obtain OSX absolute path using python: " + std::string(strerror(errno)));
+            }
+            // read in the buffer
+            while (fgets(temp, sizeof(temp), py_ret) != NULL) { }
+            pclose(py_ret);
+        #else
+            if (realpath(str().c_str(), temp) == NULL) {
+                throw std::runtime_error("Internal error in realpath(): " + std::string(strerror(errno)));
+            }
+		#endif // __APPLE__
 
 		return path(temp);
 #else


### PR DESCRIPTION
Originally issued against [`wjakob/#21`](https://github.com/wjakob/filesystem/pull/21)

I wonder what your thoughts on popen to call python are. I looked around the web for a while and am quite shocked to find that OSX seemingly really does not provide any standard routine to make absolute paths. Seriously?!!

This isn't pretty, but it at least gets the job done. Also, [`wjakob/#18`](https://github.com/wjakob/filesystem/issues/18) talks about realpath for nonexistent paths, which was the original problem I was having here. Perhaps this should change slightly and first check if the path exists. If it doesn't, regardless of OSX or Linux, use this dirty popen call?  That way people can still get absolute paths regardless of whether or not it exists.  I don't windows, so I don't know if it applies there.