### PR TITLE
make_absolute done proper (resolve against CWD)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ compiler:
   - gcc
   - clang
 install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXXFLAGS="-D__float128=void"; fi
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.9
-      - g++-4.9
+      - gcc-5
+      - g++-5
       - clang
-script: 
+script:
   - cmake . && make && ./path_demo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.4)
 project(path)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__STRICT_ANSI__")
 endif()
 add_executable(path_demo
 	path_demo.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,32 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(path)
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  # Enable C++11 mode on GCC / Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D__STRICT_ANSI__")
+
+# C++11 required for this project
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(COMPILER_IS_CLANG ON)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+else()
+  set(COMPILER_IS_CLANG OFF)
 endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(COMPILER_IS_GCC ON)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.0)
+    message(FATAL_ERROR "<codecvt> support was introduced in GCC 5.")
+  endif()
+else()
+  set(COMPILER_IS_GCC OFF)
+endif()
+
+if (COMPILER_IS_CLANG OR COMPILER_IS_GCC)
+  # Add strict ansi for __f128
+  set(CMAKE_CXX_FLAGS "-D__STRICT_ANSI__")
+endif()
+
 add_executable(path_demo
 	path_demo.cpp
 	filesystem.hpp

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -83,26 +83,26 @@ int main(int argc, char **argv) {
 
 	IS(path1, VOL SEP "dir 1" SEP "dir 2");
 
-	p = (path1 / path2); 
+	p = (path1 / path2);
 	IS(p, VOL SEP "dir 1" SEP "dir 2" SEP "dir 3");
 
-	p = (path1 / path2).dirname(); 
+	p = (path1 / path2).dirname();
 	IS(p, VOL SEP "dir 1" SEP "dir 2");
 
-	p = (path1 / path2).dirname().dirname(); 
+	p = (path1 / path2).dirname().dirname();
 	IS(p, VOL SEP "dir 1");
 
 #ifdef _WIN32
-	p = (path1 / path2).dirname().dirname().dirname(); 
+	p = (path1 / path2).dirname().dirname().dirname();
 	IS(p, VOL);
 
-	p = (path1 / path2).dirname().dirname().dirname().dirname(); 
+	p = (path1 / path2).dirname().dirname().dirname().dirname();
 	IS(p, "");
 #else
-	p = (path1 / path2).dirname().dirname().dirname(); 
+	p = (path1 / path2).dirname().dirname().dirname();
 	IS(p, SEP);
 
-	p = (path1 / path2).dirname().dirname().dirname().dirname(); 
+	p = (path1 / path2).dirname().dirname().dirname().dirname();
 	IS(p, SEP);
 #endif
 
@@ -162,6 +162,17 @@ int main(int argc, char **argv) {
 
     cout << "resolve(filesystem/path.h) = " << resolver().resolve("filesystem/path.h") << endl;
     cout << "resolve(nonexistant) = " << resolver().resolve("nonexistant") << endl;
+
+    // tests for absolute paths that do not exist
+    cout << "absolute: ./this_is_not_a_path/file.txt = " << path("./this_is_not_a_path/file.txt").make_absolute() << endl;
+    cout << "absolute: this_is_not_a_path/no_leading_dot.tar = " << path("this_is_not_a_path/no_leading_dot.tar").make_absolute() << endl;
+    cout << "absolute: . = " << path(".").make_absolute() << endl;
+    cout << "absolute: .. = " << path("..").make_absolute() << endl;
+    cout << "absolute: /var/tmp = " << path("/var/tmp").make_absolute() << endl;
+    cout << "absolute: /var/tmp and .. = " << (path("/var/tmp") / path("..")).make_absolute() << endl;
+    cout << "absolute: /not/real = " << path("/not/real").make_absolute() << endl;
+    cout << "absoulte: /not/real and .. = " << (path("/not/real") / path("..")).make_absolute() << endl;
+    cout << "absolute: /var/tmp/../www/. = " << path("/var/tmp/../www/.").make_absolute() << endl;
 
     DONE_TESTING();
 }


### PR DESCRIPTION
- Simply imports the Python implementation of `os.path.abspath` from the C source code
- License for the code is compatible: https://github.com/python/cpython/blob/master/LICENSE
    - I'm not a lawyer...maybe for safety direct links to the license should be included?  See also [wiki](https://en.wikipedia.org/wiki/Python_Software_Foundation_License)

Supercedes #5 

### Recap

`realpath` is not reliable when a given file path trying to be made absolute does not exist.

### Foreword

This is a working implementation that is merge ready (pending windows testing), but it required importing a lot of stuff.  I did what I thought was good enough to make it clear where the raw Python source code imports are, but it may be more presentable if this does not remain as a single file library.  Happy to make any changes you would like, you can also make edits directly on my branch :smile:

### Implementation notes

The python source code is all in terms of `wchar_t` pointers.  The functions being imported here are primary left as is, except for a `Py_Assert` turns into an exception throw, and the `path::cwd()` method is used rather than importing Python's `_Py_wgetcwd()` function (no real need).

You mentioned you were planning on revisiting the library, this change introduces something to be explicitly conscious of: I've been kind of wasteful in terms of the memory used for converting between `std::string` and `std::wstring`.  It seems `wstring` is really only used on Windows for some reason, but in reality (now that `detail::as_wstring` and `detail::as_string` are available), it makes more sense to allow `wstring` everywhere.

1. Non-english unix filesystems are as yet unsupported.  They definitely could be.
2. Making a `UTF-8` assumption is reasonable.  This is what Python does in v3, and it works well.  I don't know of any filesystems that use UTF-16 or UTF-32.
3. If everything is defined in terms of `std::wstring`, some of this can be alleviated.
    - Note that the preconditions on the Python methods are quite explicit: the buffers **must** be `MAXPATHLEN+1`.
    - AKA define all of `filesystem::path` in terms of `std::wstring`, and implicitly call the `detail::as_x` methods when a user wants an `std::string`.
        - I'm not super familiar with encodings in C++, this may need more consideration with respect to Locale?
4. Definitions like `SEP` from the python source code are changed to `FILESYSTEM_SEP` etc.  This is to prevent potential collisions with other projects, e.g. even with `path_demo.cpp`.  These all must be `L'/'` etc in order to use the `wchar_t` methods.
    - Not all are used, but `DELIM` for example may be useful in the future?  

### Suggestions for potential future overhaul

At some point you made some significant changes to the project setup.  With the current implementation of `make_absolute`, the single file is now _quite_ cluttered.  Given this detail, I propose

1. Make a `filesystem/` directory again, resurrecting the original `filesystem/{path,resolver,fwd}.hpp`.  As long as you e.g. `#include "fwd.hpp"` instead of `#include <fwd.hpp>`, parent projects won't have any issues.
2. Splice the python stuff out into its own file to make it even clearer what came from where.  Not sure what that would be called.
3. Spaces over tabs :wink:

3 is often a personal preference.  I am very far in the spaces camp, it seems you are in the tabs camp.  Functionality wise it doesn't matter.  It comes down to code consistency viewing across editors, as well as on GitHub.  For example, the Unix standard defines a tab character as `8` spaces, which is what GitHub will use.

### Summary

This should be the version of `make_absolute` that is desired.  I've tested on OSX and Linux, but I don't have a Windows installation to test on.  See additional tests at bottom of `path_demo.cpp`.