### PR TITLE
make_absolute resolution with CWD

### DIFF
--- a/filesystem.hpp
+++ b/filesystem.hpp
@@ -2,13 +2,13 @@
 #define FILESYSTEM_HPP__
 #pragma once
 /*
-    Filesystem utility library
+	Filesystem utility library
 
-    Copyright (c) 2015-2017 Wenzel Jakob <wenzel@inf.ethz.ch>
-    Copyright (c) 2017 Josh Junon <josh@junon.me>
+	Copyright (c) 2015-2017 Wenzel Jakob <wenzel@inf.ethz.ch>
+	Copyright (c) 2017 Josh Junon <josh@junon.me>
 
-    All rights reserved. Use of this source code is governed by a
-    BSD-style license that can be found in the LICENSE file.
+	All rights reserved. Use of this source code is governed by a
+	BSD-style license that can be found in the LICENSE file.
 */
 
 #include <string>
@@ -34,11 +34,60 @@
 	#include <linux/limits.h>
 #endif
 
+///////////////////////////////////////////////////////////////////////////////
+// Imported from:                                                            //
+// https://github.com/python/cpython/blob/master/Include/osdefs.h            //
+/* Operating system dependencies */
+#if defined(_WIN32)
+	#define FILESYSTEM_SEP '\\'
+	#define FILESYSTEM_ALTSEP '/'
+	#define FILESYSTEM_MAXPATHLEN 256
+	#define FILESYSTEM_DELIM ';'
+#endif
+
+/* Filename separator */
+#if !defined(FILESYSTEM_SEP)
+	#define FILESYSTEM_SEP '/'
+#endif
+
+/* Max pathname length */
+#ifdef __hpux
+	#include <sys/param.h>
+	#include <limits.h>
+	#if !defined(PATH_MAX)
+		#define PATH_MAX MAXPATHLEN
+	#endif
+#endif
+
+#if !defined(MAXPATHLEN)
+	#if defined(PATH_MAX) && PATH_MAX > 1024
+		#define MAXPATHLEN PATH_MAX
+	#else
+		#define MAXPATHLEN 1024
+	#endif
+#endif
+
+/* Search path entry delimiter */
+#if !defined(DELIM)
+	#define FILESYSTEM_DELIM ':'
+#endif
+// end import osdefs.h                                                       //
+///////////////////////////////////////////////////////////////////////////////
+
 namespace filesystem {
 
 class path;
 
 inline bool create_directory(const path &);
+
+// WARNING: do *NOT* call these methods directly, these exist as helpers for
+//          path::make_absolute.  Direct usage is undefined.
+namespace detail {
+	// see implementations near bottom of file
+	static void joinpath(char *buffer, char *stuff);
+	static void copy_absolute(char *path, char *p, size_t pathlen);
+	static void absolutize(char *path);
+}
 
 /**
     \brief Simple class for manipulating paths on Linux/Windows/Mac OS
@@ -142,24 +191,22 @@ public:
 	}
 
 	path make_absolute() const {
-#if !defined(_WIN32)
-		char temp[PATH_MAX];
+		try {
+			// create a buffer and call the detal absolutize method
+			char buffer[MAXPATHLEN+1];
+			strcpy(buffer, this->str().c_str());
+			detail::absolutize(buffer);
 
-		if (realpath(str().c_str(), temp) == NULL) {
-			throw std::runtime_error("Internal error in realpath(): " + std::string(strerror(errno)));
+			// create the resultant path and return it
+			path ret = path(buffer).resolve(false);// eliminate . or ..
+			ret.absolute = true;
+			return ret;
 		}
-
-		return path(temp);
-#else
-		std::wstring value = wstr(), out(MAX_PATH, '\0');
-		DWORD length = GetFullPathNameW(value.c_str(), MAX_PATH, &out[0], NULL);
-
-		if (length == 0) {
-			throw std::runtime_error("Internal error in realpath(): " + std::to_string(GetLastError()));
+		catch(const std::exception &e) {
+			throw std::runtime_error(
+				std::string("Internal error in filesystem::path::make_absolute: ") + e.what()
+			);
 		}
-
-		return path(out.substr(0, length));
-#endif
 	}
 
 	bool exists() const {
@@ -517,7 +564,7 @@ public:
 	}
 
 	/*
-	    not the safest method! use with care!
+		not the safest method! use with care!
 	*/
 	bool mkdirp() const {
 		if (!this->absolute) {
@@ -584,11 +631,11 @@ inline bool create_directory(const path &p) {
 }
 
 /**
-    \brief Simple class for resolving paths on Linux/Windows/Mac OS
+	\brief Simple class for resolving paths on Linux/Windows/Mac OS
 
-    This convenience class looks for a file or directory given its name
-    and a set of search paths. The implementation walks through the
-    search paths in order and stops once the file is found.
+	This convenience class looks for a file or directory given its name
+	and a set of search paths. The implementation walks through the
+	search paths in order and stops once the file is found.
 */
 class resolver {
 public:
@@ -667,7 +714,77 @@ private:
 	std::vector<path> m_paths;
 };
 
+///////////////////////////////////////////////////////////////////////////////
+// Imported from:                                                            //
+// https://github.com/python/cpython/blob/master/Modules/getpath.c           //
+namespace detail {
+
+/* Add a path component, by appending stuff to buffer.
+   buffer must have at least MAXPATHLEN + 1 bytes allocated, and contain a
+   NUL-terminated string with no more than MAXPATHLEN characters (not counting
+   the trailing NUL).  It's a fatal error if it contains a string longer than
+   that (callers must be careful!).  If these requirements are met, it's
+   guaranteed that buffer will still be a NUL-terminated string with no more
+   than MAXPATHLEN characters at exit.  If stuff is too long, only as much of
+   stuff as fits will be appended.
+*/
+static void joinpath(char *buffer, char *stuff) {
+	size_t n, k;
+	if (stuff[0] == FILESYSTEM_SEP)
+		n = 0;
+	else {
+		n = strlen(buffer);
+		if (n > 0 && buffer[n-1] != FILESYSTEM_SEP && n < MAXPATHLEN)
+			buffer[n++] = FILESYSTEM_SEP;
+	}
+	if (n > MAXPATHLEN)
+		throw std::runtime_error("buffer overflow in filesystem.hpp's joinpath()");
+	k = strlen(stuff);
+	if (n + k > MAXPATHLEN)
+		k = MAXPATHLEN - n;
+	strncpy(buffer+n, stuff, k);
+	buffer[n+k] = '\0';
 }
+
+/* copy_absolute requires that path be allocated at least
+   MAXPATHLEN + 1 bytes and that p be no more than MAXPATHLEN bytes. */
+static void copy_absolute(char *path, char *p, size_t pathlen) {
+	if (p[0] == FILESYSTEM_SEP)
+		strcpy(path, p);
+	else {
+		::filesystem::path cwd;
+		try {
+			cwd = path::getcwd();
+		}
+		catch(...) {
+			/* unable to get the current directory */
+			strcpy(path, p);
+			return;
+		}
+		// current working directory was discovered
+		strcpy(path, cwd.str().c_str());
+
+		if (p[0] == '.' && p[1] == FILESYSTEM_SEP)
+			p += 2;
+		joinpath(path, p);
+	}
+}
+
+/* absolutize() requires that path be allocated at least MAXPATHLEN+1 bytes. */
+static void absolutize(char *path) {
+	char buffer[MAXPATHLEN+1];
+
+	if (path[0] == FILESYSTEM_SEP)
+		return;
+	copy_absolute(buffer, path, MAXPATHLEN+1);
+	strcpy(path, buffer);
+}
+
+}// namespace detail
+// end import getpath.c                                                      //
+///////////////////////////////////////////////////////////////////////////////
+
+}// namespace filesystem
 
 namespace std {
 
@@ -696,5 +813,5 @@ private:
 	}
 };
 
-}
+}// namespace std
 #endif

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -50,29 +50,29 @@ int main(int argc, char **argv) {
     path path1(VOL SEP "dir 1" SEP "dir 2" SEP);
     path path2("dir 3");
 
-	// check empty path
-	path p;
-	IS(p.length(), 0);
-	IS(p, "");
+    // check empty path
+    path p;
+    IS(p.length(), 0);
+    IS(p, "");
 
-	p = path("");
-	IS(p.length(), 0);
-	IS(p, "");
+    p = path("");
+    IS(p.length(), 0);
+    IS(p, "");
 
 #ifdef _WIN32
     IS(path1.length(), 3);
-	IS(path1[0], "c:");
-	IS(path1[1], "dir 1");
+    IS(path1[0], "c:");
+    IS(path1[1], "dir 1");
     IS(path1[2], "dir 2");
 #else
-	IS(path1.length(), 2);
-	IS(path1[0], "dir 1");
-	IS(path1[1], "dir 2");
+    IS(path1.length(), 2);
+    IS(path1[0], "dir 1");
+    IS(path1[1], "dir 2");
 #endif
 
     NOK(path1.exists());
 
-	p = path("a/b/c/d");
+    p = path("a/b/c/d");
     IS(p.slice(1), path("b/c/d"));
     IS(p.slice(2), path("c/d"));
     IS(p.slice(0, 0), path());
@@ -81,35 +81,35 @@ int main(int argc, char **argv) {
     IS(p.slice(0, 2), path("a/b"));
     IS(p.slice(0, 3), path("a/b/c"));
 
-	IS(path1, VOL SEP "dir 1" SEP "dir 2");
+    IS(path1, VOL SEP "dir 1" SEP "dir 2");
 
-	p = (path1 / path2); 
-	IS(p, VOL SEP "dir 1" SEP "dir 2" SEP "dir 3");
+    p = (path1 / path2);
+    IS(p, VOL SEP "dir 1" SEP "dir 2" SEP "dir 3");
 
-	p = (path1 / path2).dirname(); 
-	IS(p, VOL SEP "dir 1" SEP "dir 2");
+    p = (path1 / path2).dirname();
+    IS(p, VOL SEP "dir 1" SEP "dir 2");
 
-	p = (path1 / path2).dirname().dirname(); 
-	IS(p, VOL SEP "dir 1");
+    p = (path1 / path2).dirname().dirname();
+    IS(p, VOL SEP "dir 1");
 
 #ifdef _WIN32
-	p = (path1 / path2).dirname().dirname().dirname(); 
-	IS(p, VOL);
+    p = (path1 / path2).dirname().dirname().dirname();
+    IS(p, VOL);
 
-	p = (path1 / path2).dirname().dirname().dirname().dirname(); 
-	IS(p, "");
+    p = (path1 / path2).dirname().dirname().dirname().dirname();
+    IS(p, "");
 #else
-	p = (path1 / path2).dirname().dirname().dirname(); 
-	IS(p, SEP);
+    p = (path1 / path2).dirname().dirname().dirname();
+    IS(p, SEP);
 
-	p = (path1 / path2).dirname().dirname().dirname().dirname(); 
-	IS(p, SEP);
+    p = (path1 / path2).dirname().dirname().dirname().dirname();
+    IS(p, SEP);
 #endif
 
-	p = path().dirname();
-	IS(p, "..");
+    p = path().dirname();
+    IS(p, "..");
 
-	cout << (path1/path1.as_relative()) << endl;
+    cout << (path1/path1.as_relative()) << endl;
 
     cout << "some/path.ext:operator==() = " << (path("some/path.ext") == path("some/path.ext")) << endl;
     cout << "some/path.ext:operator==() (unequal) = " << (path("some/path.ext") == path("another/path.ext")) << endl;
@@ -162,6 +162,17 @@ int main(int argc, char **argv) {
 
     cout << "resolve(filesystem/path.h) = " << resolver().resolve("filesystem/path.h") << endl;
     cout << "resolve(nonexistant) = " << resolver().resolve("nonexistant") << endl;
+
+    // tests for absolute paths that do not exist
+    cout << "absolute: ./this_is_not_a_path/file.txt = " << path("./this_is_not_a_path/file.txt").make_absolute() << endl;
+    cout << "absolute: this_is_not_a_path/no_leading_dot.tar = " << path("this_is_not_a_path/no_leading_dot.tar").make_absolute() << endl;
+    cout << "absolute: . = " << path(".").make_absolute() << endl;
+    cout << "absolute: .. = " << path("..").make_absolute() << endl;
+    cout << "absolute: /var/tmp = " << path("/var/tmp").make_absolute() << endl;
+    cout << "absolute: /var/tmp and .. = " << (path("/var/tmp") / path("..")).make_absolute() << endl;
+    cout << "absolute: /not/real = " << path("/not/real").make_absolute() << endl;
+    cout << "absoulte: /not/real and .. = " << (path("/not/real") / path("..")).make_absolute() << endl;
+    cout << "absolute: /var/tmp/../www/. = " << path("/var/tmp/../www/.").make_absolute() << endl;
 
     DONE_TESTING();
 }


### PR DESCRIPTION
- modification of python source code
- does not use `wchar_t` for compatibility, since <codecvt>
  requires slightly modern compilers

This is the alternative to #6, still needs windows testing, but eliminates `wchar_t` altogether.  Choose one or neither, but not both!