### PR TITLE
Add meson build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8.4)
-project(path)
+project(filesystem)
+
+message (WARNING "CMake configuration for filesystem.hpp is DEPRECATED. Please use the Meson dependency instead. https://mesonbuild.com/Tutorial.html")
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")

--- a/README.md
+++ b/README.md
@@ -8,5 +8,15 @@ system's filesystem.
 See `filesystem.hpp` (which contains all relevant code) for API and `path_demo.cpp`
 for usage examples.
 
+## Usage
+
+To use in your Meson project, check this repository out to `subprojects/filesystem` and add
+the following lines to your `meson.build`:
+
+```meson
+filesystem = subproject('filesystem').get_variable('dep')
+executable('my-app', 'app.cc', dependencies: [filesystem])
+```
+
 # License
 Licensed under the [BSD 2-Clause License](LICENSE).

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,7 @@
+project('filesystem', 'cpp', default_options: ['cpp_std=c++11'])
+
+inc = include_directories('.')
+dep = declare_dependency(include_directories: inc)
+
+test_exe = executable('path_demo', 'path_demo.cpp', dependencies: [dep])
+test('filesystem-test', test_exe, args: [])


### PR DESCRIPTION
Also deprecates CMake (not that it really matters to anyone). Meson actually gives you the include directories, though.