### PR TITLE
define NOMINMAX so that std::min and std::max may be used

### DIFF
--- a/filesystem.hpp
+++ b/filesystem.hpp
@@ -11,6 +11,10 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+// miwindef.h defines min and max macros, these conflict with std::min and std::max
+// defining NOMINMAX, the min and max are not defined
+#define NOMINMAX
+
 #include <string>
 #include <vector>
 #include <stdexcept>


### PR DESCRIPTION
Without this define, sources using std::min and std::max and including filesystem.hpp in Windows do not compile.